### PR TITLE
avoid {}s in generated Makefile code to avoid breaking dmake

### DIFF
--- a/lib/Inline/MakeMaker.pm
+++ b/lib/Inline/MakeMaker.pm
@@ -94,9 +94,10 @@ END
 
 MAKEFILE
     for (0..$#objects) {
+        # the subdivision in hashes is done to avoid {}, which break dmake
         print MAKEFILE <<MAKEFILE;
 $obj_rules[$_]: \$(TO_INST_PM)
-\t\$(PERL) -Mblib -MInline=NOISY,_INSTALL_ -M$objects[$_] -e"Inline::satisfy_makefile_dep({API => {modinlname => '$obj_rules[$_]', module => '$objects[$_]'}});" $version \$(INST_ARCHLIB)
+\t\$(PERL) -Mblib -MInline=NOISY,_INSTALL_ -M$objects[$_] -e"my %A = (modinlname => '$obj_rules[$_]', module => '$objects[$_]'); my %S = (API => \\%A); Inline::satisfy_makefile_dep(\\%S);" $version \$(INST_ARCHLIB)
 MAKEFILE
     }
 


### PR DESCRIPTION
dmake handles { and } in a special manner, which means that `$(INST_ARCHLIB)` was never interpolated, but passed on as it is, which in turn broke the cleanup phase of Inline::C.

They could be interpolated for dmake, and EUMM does that usually when generating, but it's less of a hassle to simply avoid them in the first place.

Fixes ingydotnet/inline-c-pm#36