### PR TITLE
Calculate MD5 hashes of UTF-8 source by encoding it first

### DIFF
--- a/lib/Inline.pm
+++ b/lib/Inline.pm
@@ -7,9 +7,11 @@ use Inline::denter;
 use Config;
 use Carp;
 use Cwd qw(abs_path cwd);
+use Encode;
 use File::Spec;
 use File::Spec::Unix;
 use Fcntl qw(LOCK_EX LOCK_UN);
+use utf8;
 
 my %CONFIG = ();
 my @DATA_OBJS = ();
@@ -459,7 +461,11 @@ sub check_installed {
     $o->{INLINE}{object_ready} = 0;
     unless ($o->{API}{code} =~ /^[A-Fa-f0-9]{32}$/) {
         require Digest::MD5;
-        $o->{INLINE}{md5} = Digest::MD5::md5_hex($o->{API}{code});
+        my $encoded_code = $o->{API}{code};
+        if ( utf8::is_utf8($encoded_code)) {
+            $encoded_code = Encode::encode_utf8($encoded_code);
+        }
+        $o->{INLINE}{md5} = Digest::MD5::md5_hex($encoded_code);
     }
     else {
         $o->{INLINE}{md5} = $o->{API}{code};

--- a/lib/Inline/Foo.pm
+++ b/lib/Inline/Foo.pm
@@ -63,6 +63,7 @@ sub build {
     $o->mkpath($path) unless -d $path;
     open FOO_OBJ, "> $obj"
       or croak "Can't open $obj for output\n$!";
+    binmode(FOO_OBJ, ':utf8');
     print FOO_OBJ $code;
     close \*FOO_OBJ;
 }
@@ -72,6 +73,7 @@ sub load {
     my $obj = $o->{API}{location};
     open FOO_OBJ, "< $obj"
       or croak "Can't open $obj for output\n$!";
+    binmode(FOO_OBJ, ':utf8');
     my $code = join '', <FOO_OBJ>;
     close \*FOO_OBJ;
     eval "package $o->{API}{pkg};\n$code";

--- a/test/08unicode.t
+++ b/test/08unicode.t
@@ -1,0 +1,19 @@
+use strict; use warnings; use utf8;
+binmode(STDOUT, ':utf8');
+binmode(STDERR, ':utf8');
+use lib -e 't' ? 't' : 'test';
+use TestInlineSetup;
+
+use Test::More tests => 1;
+
+use Inline Config => DIrECTORY => $TestInlineSetup::DIR, DISABLE => 'WARNINGS';
+
+ok(test2('𝘛𝘩𝘪𝘴 𝘪𝘴 𝘜𝘯𝘪𝘤𝘰𝘥𝘦 𝘵𝘦𝘹𝘵.'), 'UTF-8');
+use Inline Foo => ConFig => ENABLE => 'BaR';
+use Inline Foo => <<'END_OF_FOO', PAtTERN => 'gogo-';
+use utf8;
+
+gogo-sub test2 {
+    bar-return $_[0] gogo-eq '𝘛𝘩𝘪𝘴 𝘪𝘴 𝘜𝘯𝘪𝘤𝘰𝘥𝘦 𝘵𝘦𝘹𝘵.';
+}
+END_OF_FOO


### PR DESCRIPTION
When `use utf8` is being used in the caller code and the inline source code passed has Unicode literals, “Inline” module was failing to calculate MD5 hash of the code without decoding it first.