### PR TITLE
Fix failing tests on systems missing perldiag.pod

### DIFF
--- a/test/01usages.t
+++ b/test/01usages.t
@@ -6,6 +6,22 @@ use Test::More;
 
 use Inline conFig => DiREcTOrY => $TestInlineSetup::DIR;
 
+unless ($TestInlineSetup::DIAG) {
+    diag <<'EOD'
+Unable to load diagnostics module, test results are unaffected.
+
+The diagnostics module cannot be loaded. The module gets its
+explanations for messages from the perldoc file perldiag.pod.
+
+Although both the module and the perldoc file are core parts of perl,
+some packaging systems distribute them in separate packages.
+
+E.g. in Cygwin this package is called perl_pods. Installing this
+package should make the diagnostics module load correctly.
+
+EOD
+}
+
 use Inline Foo => File::Spec->catfile(File::Spec->curdir(),$t,'file');
 ok(test1('test1'), 'read external file');
 

--- a/test/TestInlineSetup.pm
+++ b/test/TestInlineSetup.pm
@@ -1,7 +1,12 @@
 use strict; use warnings;
 package TestInlineSetup;
 
-use diagnostics;
+our $DIAG =  eval {
+    require diagnostics;
+    diagnostics->import();
+    1;
+};
+
 use File::Path;
 use File::Spec;
 


### PR DESCRIPTION
Replaced 'use diagnostics' with an eval. This way tests will continue
on systems where perldiag.pod (that diagnostics depend on) is missing.
This is most notably on Cygwin, where POD files are in a separate
package called perl_pods.

This is part of the CPAN Pull Request Challenge, where I got Inline
as my March assignment.