### PR TITLE
Reference Inline::Module in docs related to installation

### DIFF
--- a/doc/Inline.swim
+++ b/doc/Inline.swim
@@ -263,6 +263,12 @@ following syntaxes:
   ie './file.ext' instead of simply 'file.ext'.) These methods are less
   frequently used but may be useful in some situations.
 
+  For instance, to load your C++ code from a file named the same as your perl
+  module with a swapped file extension, you can use:
+
+    use Inline CPP => (__FILE__ =~ s/\.pm$/.cpp/r);
+
+
 - Shorthand
 
   If you are using the 'DATA' or 'file' methods described above *and* there are
@@ -596,7 +602,8 @@ language specific configuration, see the doc for that language.
   Specifies the version number of the Inline extension object. It is used
   *only* for modules, and it must match the global variable $VERSION.
   Additionally, this option should used if (and only if) a module is being set
-  up to be installed permanently into the Perl sitelib tree. Inline will croak
+  up to be installed permanently into the Perl sitelib tree using
+  Inline::MakeMaker (NOT used by Inline::Module). Inline will croak
   if you use it otherwise.
 
   The presence of the `version` parameter is the official way to let Inline
@@ -822,9 +829,20 @@ used for additional purposes.
 
 = Writing Modules with Inline
 
-Writing CPAN modules that use C code is easy with Inline. Let's say that you
-wanted to write a module called `Math::Simple`. Start by using the following
-command:
+The current preferred way to author CPAN modules with Inline is to use
+Inline::Module (distributed separately).  Inline ships with Inline::MakeMaker,
+which helps you set up a Makefile.PL that invokes Inline at install time to
+compile all the code before it gets installed, but the resulting module still
+depends on Inline and the language support module like Inline::C.  In order to
+avoid this dependency, what you really want to do is convert your distribution
+to plain XS before uploading it to CPAN.  Inline::Module fills that role, and
+also integrates well with more modern authoring tools.
+
+See Inline::Module for details on that approach, or continue reading below for
+the older Inline::MakeMaker technique.
+
+Let's say that you wanted to write a module called `Math::Simple`. Start by
+using the following command:
 
   h2xs -PAXn Math::Simple
 
@@ -866,7 +884,7 @@ Next, modify the `Simple.pm` file to look like this:
 The important things to note here are that you *must* specify a `name` and
 `version` parameter. The `name` must match your module's package name. The
 `version` parameter must match your module's `$VERSION` variable and they must
-be of the form `/^\d\.\d\d$/`.
+be considered valid by `version::parse`.
 
 NOTE: These are Inline's sanity checks to make sure you know what you're doing
 before uploading your code to CPAN. They insure that once the module has been

--- a/doc/Inline/FAQ.swim
+++ b/doc/Inline/FAQ.swim
@@ -33,6 +33,20 @@ rules about how `[_.]Inline/` directories are used\/created. But it was
 designed to give you the most flexibility\/ease-of-use. Never be afraid to
 nuke 'em. They'll just pop right back next time they're needed.  :)
 
+== What is the best way to package Inline code for CPAN?
+
+This distribution includes Inline::MakeMaker, described below, which takes
+special steps during the installation of your module to make sure the code
+gets compiled and installed, rather than compiled by users at runtime.
+But, users of your module need to install Inline and the language support
+module like Inline::CPP as prerequisites for your module.
+
+A better way to distribute your module is with Inline::Module, which takes
+special steps to remove dependencies on Inline::* and convert it to a
+plain XS module during the construction of your distribution before you
+upload it to CPAN.  It also integrates easily with Dist::Zilla and other
+modern authoring tools for a more streamlined authoring experience.
+
 == Whatever happened to the `SITE_INSTALL` option?
 
 `SITE_INSTALL` is gone. I was going to leave it in and change the semantics,


### PR DESCRIPTION
The documentation about how to install Inline-derived modules was
all referencing Inline::MakeMaker, though Inline::Module delivers
better results.  Updated all relevant doc sections to direct users
to Inline::Module.

One additional improvement that could be made here is to render
the module name Inline::Module as a POD L<> link, but I don't know
how to do that with swim.