### PR TITLE
Merge per-language config, not overwrite

### DIFF
--- a/lib/Inline.pm
+++ b/lib/Inline.pm
@@ -138,20 +138,20 @@ sub import_heavy {
             Inline::Files::get_filename($pkg)
            ) {
             $o->read_inline_file;
-            $o->{CONFIG} = handle_language_config(@config);
+            $o->{CONFIG} = handle_language_config($o->{CONFIG}, @config);
         }
         elsif ($option eq 'DATA' or not $option) {
-            $o->{CONFIG} = handle_language_config(@config);
+            $o->{CONFIG} = handle_language_config($o->{CONFIG}, @config);
             push @DATA_OBJS, $o;
             return;
         }
         elsif (uc $option eq uc 'Config') {
-            $CONFIG{$pkg}{$language_id} = handle_language_config(@config);
+            $CONFIG{$pkg}{$language_id} = handle_language_config($CONFIG{$pkg}{$language_id}, @config);
             return;
         }
         else {
             $o->receive_code($option);
-            $o->{CONFIG} = handle_language_config(@config);
+            $o->{CONFIG} = handle_language_config($o->{CONFIG}, @config);
         }
     }
     else {
@@ -191,7 +191,7 @@ sub bind {
     $o->{API}{script} = $script;
     $o->{API}{language_id} = $language_id;
     $o->receive_code($code);
-    $o->{CONFIG} = handle_language_config(@config);
+    $o->{CONFIG} = handle_language_config($o->{CONFIG}, @config);
 
     $o->glue;
 }
@@ -590,6 +590,7 @@ sub handle_global_config {
 # Process the config options that apply to a particular language
 #==============================================================================
 sub handle_language_config {
+    my %merge_with = %{ shift || {} };
     my @values;
     while (@_) {
         my ($key, $value) = (uc shift, shift);
@@ -604,7 +605,7 @@ sub handle_language_config {
             push @values, $key, $value;
         }
     }
-    return {@values};
+    return {%merge_with, @values};
 }
 
 #==============================================================================

--- a/test/02config.t
+++ b/test/02config.t
@@ -15,6 +15,7 @@ END_OF_FOO
 
 ok(test2('test2'), 'PATTERN');
 use Inline Foo => ConFig => ENABLE => 'BaR';
+use Inline Foo => ConFig =>; # check accumulates instead of reset
 use Inline Foo => <<'END_OF_FOO', PAtTERN => 'gogo-';
 gogo-sub test2 {
     bar-return $_[0] gogo-eq 'test2';


### PR DESCRIPTION
Current behaviour is for global Inline config to merge, but per-language to overwrite, which is quite surprising for users. This fixes that.

This will fix https://github.com/ingydotnet/inline-c-pm/issues/87, and fix https://github.com/ingydotnet/inline-c-pm/issues/82.