### PR TITLE
Do not damage multiline environment variables in env_untaint()

### DIFF
--- a/lib/Inline.pm
+++ b/lib/Inline.pm
@@ -1086,7 +1086,7 @@ sub env_untaint {
     {
     no warnings ('uninitialized'); # In case $ENV{$_} is set to undef.
       for (keys %ENV) {
-          ($ENV{$_}) = $ENV{$_} =~ /(.*)/;
+          ($ENV{$_}) = $ENV{$_} =~ /(.*)/s;
       }
     }
 


### PR DESCRIPTION
If an enviroment variable has a multiline value, the value was cut at a newline character in env_untaint() function, effectively damaging the variable:

~~~~
$ perl -Ilib -e 'use Inline; $ENV{foo}="a\nb"; Inline::env_untaint(); print "<$ENV{foo}>\n"'
In Inline::env_untaint() : Blindly untainting tainted fields in %ENV.
<a>
~~~~

A variable like this exists on RHEL 9 system. (A bash function exported by a login script of "which" RPM package.) Inline-C t/08taint.t test then printed plenty of errors:

~~~~
$ prove -I../../perl-Inline/Inline-0.86/lib -Ilib t/08taint.t
t/08taint.t .. 1/10 sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
t/08taint.t .. 2/10 sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
t/08taint.t .. 5/10 sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
sh: which: line 1: syntax error: unexpected end of file
sh: error importing function definition for `which'
t/08taint.t .. ok
All tests successful.
~~~~

This patch fixes it by changing the regular expression to a single-line mode.