### PR TITLE
Prevent indexing of Foo::Tester package

### DIFF
--- a/lib/Inline/Foo.pm
+++ b/lib/Inline/Foo.pm
@@ -53,7 +53,8 @@ sub build {
     $code =~ s/$pattern//g;
     $code =~ s/bar-//g if $o->{ILSM}{BAR};
     {
-        package Foo::Tester;
+        package
+            Foo::Tester;
         our $VERSION = '0.02';
         eval $code;
     }


### PR DESCRIPTION
Various tools currently index Foo::Tester as a real package. Adding the newline is the common way to prevent that.