### PR TITLE
Fix file locking, remove 2-arg open

### DIFF
--- a/lib/Inline.pm
+++ b/lib/Inline.pm
@@ -750,7 +750,7 @@ sub check_config_file {
 
        my $load_cfg = sub {
            $o->create_config_file($DIRECTORY)
-             if not -e File::Spec->catfile($DIRECTORY, $configuration_file);
+             if not -s File::Spec->catfile($DIRECTORY, $configuration_file);
 
            open my $fh, "<", File::Spec->catfile($DIRECTORY,$configuration_file)
              or croak M17_config_open_failed($DIRECTORY);


### PR DESCRIPTION
... and remove bareword handles.

Specifically:

- Reading a file doesn't require an exclusive lock; a shared lock is fine.
- Writing a file should use an exclusive lock, but the previous code would truncate the file first (open mode `>`) and only then acquire a lock.
- Explicitly unlocking a file before closing is unsafe in general because there may be unwritten data sitting in the buffer. `close` will flush the buffer and write the data, but if the lock is already released, it may clash with other writers.